### PR TITLE
Don't unnecessarily initialize buffer contents

### DIFF
--- a/source/nogc/conv.d
+++ b/source/nogc/conv.d
@@ -21,7 +21,7 @@ auto text(size_t bufferSize = BUFFER_SIZE, Allocator = Mallocator, Args...)
 
     alias String = StringA!Allocator;
 
-    scope char[bufferSize] buffer;
+    scope char[bufferSize] buffer = void;
     String ret;
 
     foreach(ref const arg; args) {


### PR DESCRIPTION
With a default buffer size of 1KB it's probably worth avoiding this.