### PR TITLE
Missing import for save

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,80 @@
+platform: x64
+environment:
+ matrix:
+  - DC: dmd
+    DVersion: 2.085.0
+    arch: x64
+  - DC: dmd
+    DVersion: 2.085.0
+    arch: x86
+
+skip_tags: true
+
+install:
+  - ps: function SetUpDCompiler
+        {
+            if($env:DC -eq "dmd"){
+              if($env:arch -eq "x86"){
+                $env:DConf = "m32";
+              }
+              elseif($env:arch -eq "x64"){
+                $env:DConf = "m64";
+              }
+              echo "downloading ...";
+              $env:toolchain = "msvc";
+              $version = $env:DVersion;
+              Invoke-WebRequest "http://downloads.dlang.org/releases/2.x/$($version)/dmd.$($version).windows.7z" -OutFile "c:\dmd.7z";
+              echo "finished.";
+              pushd c:\\;
+              7z x dmd.7z > $null;
+              popd;
+            }
+            elseif($env:DC -eq "ldc"){
+              echo "downloading ...";
+              if($env:arch -eq "x86"){
+                $env:DConf = "m32";
+              }
+              elseif($env:arch -eq "x64"){
+                $env:DConf = "m64";
+              }
+              $env:toolchain = "msvc";
+              $version = $env:DVersion;
+              Invoke-WebRequest "https://github.com/ldc-developers/ldc/releases/download/v$($version)/ldc2-$($version)-win64-msvc.zip" -OutFile "c:\ldc.zip";
+              echo "finished.";
+              pushd c:\\;
+              7z x ldc.zip > $null;
+              popd;
+            }
+        }
+  - ps: SetUpDCompiler
+
+before_build:
+  - ps: if($env:arch -eq "x86"){
+            $env:compilersetupargs = "x86";
+            $env:Darch = "x86";
+          }
+        elseif($env:arch -eq "x64"){
+            $env:compilersetupargs = "amd64";
+            $env:Darch = "x86_64";
+        }
+  - ps : if($env:DC -eq "dmd"){
+           $env:PATH += ";C:\dmd2\windows\bin;";
+         }
+         elseif($env:DC -eq "ldc"){
+           $version = $env:DVersion;
+           $env:PATH += ";C:\ldc2-$($version)-win64-msvc\bin";
+           $env:DC = "ldc2";
+         }
+  - ps: $env:compilersetup = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall";
+  - '"%compilersetup%" %compilersetupargs%'
+
+build_script:
+ - echo dummy build script - dont remove me
+
+test_script:
+ - echo %PLATFORM%
+ - echo %Darch%
+ - echo %DC%
+ - echo %PATH%
+ - '%DC% --version'
+ - dub test

--- a/source/nogc/conv.d
+++ b/source/nogc/conv.d
@@ -131,7 +131,7 @@ private auto value(Allocator = Mallocator, T)(ref const(T) arg) if(is(T == strin
 private auto value(Allocator = Mallocator, T)(T arg) if(from.std.range.primitives.isInputRange!T && !is(T == string)) {
 
     import automem.vector: StringA;
-    import std.range: hasLength, isForwardRange, walkLength;
+    import std.range: hasLength, isForwardRange, walkLength, save;
 
     StringA!Allocator ret;
 


### PR DESCRIPTION
example error message without this:
`/home/john/.dub/packages/nogc-0.3.0/nogc/source/nogc/conv.d(143,27): Error: no property save for type char[]`

Because `char[]` doesn't match `hasLength` of course, because **&@*(&(*&@*ing autodecoding.